### PR TITLE
Temporarily force 1-sample top_k=2 failure always

### DIFF
--- a/tests/test_knn_classifier.py
+++ b/tests/test_knn_classifier.py
@@ -116,7 +116,7 @@ class TestKnnClassifier:
         assert labels.shape == (1,)
         assert similar_samples.shape == (top_k, 1)
 
-        test_set_size = random.randint(1, 50)
+        test_set_size = random.randint(1, 1)  # FIXME: Put upper bound back to 50.
         test_set = [self.sample_input for _ in range(test_set_size)]
         top_k = 2
         (distance, labels, similar_samples) = self.model.predict(test_set, top_k)


### PR DESCRIPTION
This temporarily modifies test_predict so it produces the problem
in every test run, in order to verify that the immediately
forthcoming fix is effective.

Because this commit decreases the general usefulness of the test,
it needs to be undone/reverted after that has been verified.