### PR TITLE
Show difficulties with making same dev container support and install original codebase

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,5 @@
 {
     "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
-    "features": {
-        "ghcr.io/devcontainers-contrib/features/poetry:2": {}
-    },
     "customizations": {
         "vscode": {
             "extensions": [
@@ -21,5 +18,6 @@
                 "gitlens.showWhatsNewAfterUpgrades": false
             }
         }
-    }
+    },
+    "onCreateCommand": [".devcontainer/onCreate"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "bierner.markdown-preview-github-styles",
+                "eamodio.gitlens",
+                "GitHub.vscode-github-actions",
+                "GitHub.vscode-pull-request-github",
+                "mhutchie.git-graph",
+                "ms-python.isort",
+                "ms-python.python",
+                "ms-toolsai.jupyter",
+                "tamasfe.even-better-toml"
+            ],
+            "settings": {
+                "gitlens.showWelcomeOnInstall": false,
+                "gitlens.showWhatsNewAfterUpgrades": false
+            }
+        }
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,14 +3,11 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "bierner.markdown-preview-github-styles",
                 "eamodio.gitlens",
-                "GitHub.vscode-github-actions",
                 "GitHub.vscode-pull-request-github",
                 "mhutchie.git-graph",
                 "ms-python.isort",
                 "ms-python.python",
-                "ms-toolsai.jupyter",
                 "tamasfe.even-better-toml"
             ],
             "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,8 @@
 {
     "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
+    "features": {
+        "ghcr.io/devcontainers-contrib/features/poetry:2": {}
+    },
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
+    "image": "mcr.microsoft.com/devcontainers/python:1-3.10-bookworm",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/onCreate
+++ b/.devcontainer/onCreate
@@ -8,3 +8,7 @@ pipx inject poetry poetry-plugin-sort poetry-plugin-up
 
 # Set up project environment for poetry.
 poetry install
+
+# Modify the project environment so it can run all examples with no GPU.
+poetry run pip install -U pip setuptools wheel
+poetry run pip install torch --index-url https://download.pytorch.org/whl/cpu

--- a/.devcontainer/onCreate
+++ b/.devcontainer/onCreate
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+# Set up Poetry and its plugins.
+pipx install poetry
+pipx inject poetry poetry-plugin-sort poetry-plugin-up
+
+# Set up project environment for poetry.
+poetry install


### PR DESCRIPTION
This PR, which is internal to my fork, should remain a draft and never be merged. I intend to close it. Its purpose is to preserve a record of an alternative approach to the dev container configured I had explored, that used a Python 3.10 dev container image and attempted (but did not succeed) supporting the original codebase comparably well to the new codebase. The main reason for my wanting to preserve a record of this is so that context is not lost in bazingagin#34, whose description originally linked to the branch (which I have deleted) and now links here.